### PR TITLE
Fixing memory leaks when making data and making predictions.

### DIFF
--- a/ffm.cpp
+++ b/ffm.cpp
@@ -743,6 +743,7 @@ ffm_float ffm_train_iteration(ffm_problem& prob, ffm_model& model, ffm_parameter
         wTx(begin, end, r, model, kappa, params.eta, params.lambda, true);
     }
 
+    delete [] idx;
     return loss / len;
 }
 
@@ -840,6 +841,17 @@ ffm_float ffm_predict_array(ffm_node* nodes, int len, ffm_model &model) {
     ffm_node* end = begin + len;
 
     return ffm_predict(begin, end, model);
+}
+
+void ffm_cleanup_prediction(ffm_float* f) {
+    delete [] f;
+}
+
+void ffm_cleanup_data(ffm_problem *p) {
+    delete [] p->data;
+    delete [] p->pos;
+    delete [] p->labels;
+    delete [] p->scales;
 }
 
 } // namespace ffm

--- a/ffm.h
+++ b/ffm.h
@@ -76,6 +76,8 @@ void ffm_save_model_c_string(ffm_model &model, char *path);
 
 ffm_problem ffm_convert_data(ffm_line *data, ffm_int num_lines);
 
+void ffm_cleanup_data(ffm_problem *p);
+
 ffm_model ffm_init_model(ffm_problem &data, ffm_parameter params);
 
 ffm_float ffm_train_iteration(ffm_problem &data, ffm_model &model, ffm_parameter params);
@@ -83,6 +85,8 @@ ffm_float ffm_train_iteration(ffm_problem &data, ffm_model &model, ffm_parameter
 ffm_float ffm_predict_array(ffm_node *nodes, int len, ffm_model &model);
 
 ffm_float* ffm_predict_batch(ffm_problem &data, ffm_model &model);
+
+void ffm_cleanup_prediction(ffm_float* f);
 
 } // namespace ffm
 


### PR DESCRIPTION
This addresses: https://github.com/alexeygrigorev/libffm-python/issues/1 with the following changes:

1. Implement a C++ function `ffm_cleanup_data` that deletes the pointer to an `ffm_problem` struct that contains a dataset. This was the primary source of the memory growth.
2. Implement a C++ function `ffm_cleanup_prediction` that deletes the pointer to the `ffm_float` array of predictions.
3. Use `ffm_cleanup_data` in the python `FFMData.__del__` function. Thus, the data will be freed when an `FFMData` object is explicitly deleted via `del` or when it is overwritten.
4. Use `ffm_cleanup_prediction` in the python `FFM.predict` function. The predictions are copied to a numpy array before being deleted.

My editor/linter might have added some new lines - sorry about that.

To reproduce the bug and see the fix:

Recompile the library:
```
make so
mv libffm.so ffm
pip uninstall ffm -y
python setup.py install
```

Save and run the script below twice: 
once with `python <script name>.py --delete`
once with `python <script name>.py`. 
```
import numpy as np
import resource
import matplotlib
matplotlib.use('agg')
import matplotlib.pyplot as plt
import ffm
import argparse

ap = argparse.ArgumentParser(description='')
ap.add_argument('--delete', action='store_true')
args = vars(ap.parse_args())
delete = args['delete']

N = 10000
X = [[(1, 2, 1), (2, 3, 1), (3, 5, 1)]] * N
y = np.random.rand(N).round()
model = ffm.FFM(eta=0.1, lam=0.0001, k=4)
mems = []

# Overwrite the __del__ method to show that it makes a difference.
if not delete:
    ffm.FFMData.__del__ = lambda x: 0

for i in range(20):
    model = ffm.FFM(eta=0.1, lam=0.0001, k=4)
    ffm_data = ffm.FFMData(X, y)
    model.init_model(ffm_data)
    for _ in range(5):
        model.iteration(ffm_data)
    yp = model.predict(ffm_data)
    mems.append(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
    print(i, mems[-1])

plt.title('Memory usage %s' % ('with delete' if delete else 'without delete'))
plt.plot(mems)
plt.ylabel('memory usage (KB)')
plt.xlabel('trials')
plt.savefig('mem-%s.png' % ('delete' if delete else 'no-delete'))
plt.close()
```

When the `__del__` function is properly implemented, you'll see memory growth like this:
![image](https://user-images.githubusercontent.com/8015228/33084249-70fbaba8-ceaf-11e7-8973-1678a3782b10.png)

When the `__del__` function is not being used, you'll see memory growth like this:
![image](https://user-images.githubusercontent.com/8015228/33084262-7a0627fa-ceaf-11e7-931e-4e97e8bba980.png)

Also, thanks to @gbruer15 for helping out with the memory leak fix.