### PR TITLE
get_W function to get model vectors

### DIFF
--- a/ffm.cpp
+++ b/ffm.cpp
@@ -70,6 +70,14 @@ ffm_long get_w_size(ffm_model &model) {
     return (ffm_long) model.n * model.m * k_aligned * 2;
 }
 
+ffm_int ffm_get_kALIGN() {
+    return kALIGN;
+}
+
+ffm_int ffm_get_k_aligned(ffm_int k) {
+    return (ffm_int) ceil((ffm_float)k / kALIGN) * kALIGN;
+}
+
 #if defined USESSE
 inline ffm_float wTx(
     ffm_node *begin,
@@ -700,6 +708,11 @@ ffm_problem ffm_convert_data(ffm_line* data, ffm_int num_lines) {
 }
 
 ffm_model ffm_init_model(ffm_problem& problem, ffm_parameter params) {
+		// to suppress warning for not used functions
+		// these functions are only used in the python wrapper
+		(void)ffm_get_kALIGN;
+		(void)ffm_get_k_aligned;
+		
     int n = problem.n;
     int m = problem.m;
     return init_model(n, m, params);

--- a/ffm.cpp
+++ b/ffm.cpp
@@ -70,13 +70,6 @@ ffm_long get_w_size(ffm_model &model) {
     return (ffm_long) model.n * model.m * k_aligned * 2;
 }
 
-ffm_int ffm_get_kALIGN() {
-    return kALIGN;
-}
-
-ffm_int ffm_get_k_aligned(ffm_int k) {
-    return (ffm_int) ceil((ffm_float)k / kALIGN) * kALIGN;
-}
 
 #if defined USESSE
 inline ffm_float wTx(
@@ -710,8 +703,6 @@ ffm_problem ffm_convert_data(ffm_line* data, ffm_int num_lines) {
 ffm_model ffm_init_model(ffm_problem& problem, ffm_parameter params) {
 		// to suppress warning for not used functions
 		// these functions are only used in the python wrapper
-		(void)ffm_get_kALIGN;
-		(void)ffm_get_k_aligned;
 		
     int n = problem.n;
     int m = problem.m;
@@ -865,6 +856,14 @@ void ffm_cleanup_data(ffm_problem *p) {
     delete [] p->pos;
     delete [] p->labels;
     delete [] p->scales;
+}
+
+ffm_int ffm_get_kALIGN() {
+    return kALIGN;
+}
+
+ffm_int ffm_get_k_aligned(ffm_int k) {
+    return (ffm_int) ceil((ffm_float)k / kALIGN) * kALIGN;
 }
 
 } // namespace ffm

--- a/ffm.cpp
+++ b/ffm.cpp
@@ -70,7 +70,6 @@ ffm_long get_w_size(ffm_model &model) {
     return (ffm_long) model.n * model.m * k_aligned * 2;
 }
 
-
 #if defined USESSE
 inline ffm_float wTx(
     ffm_node *begin,
@@ -700,10 +699,7 @@ ffm_problem ffm_convert_data(ffm_line* data, ffm_int num_lines) {
     return result;
 }
 
-ffm_model ffm_init_model(ffm_problem& problem, ffm_parameter params) {
-		// to suppress warning for not used functions
-		// these functions are only used in the python wrapper
-		
+ffm_model ffm_init_model(ffm_problem& problem, ffm_parameter params) {		
     int n = problem.n;
     int m = problem.m;
     return init_model(n, m, params);

--- a/ffm.cpp
+++ b/ffm.cpp
@@ -699,7 +699,7 @@ ffm_problem ffm_convert_data(ffm_line* data, ffm_int num_lines) {
     return result;
 }
 
-ffm_model ffm_init_model(ffm_problem& problem, ffm_parameter params) {		
+ffm_model ffm_init_model(ffm_problem& problem, ffm_parameter params) {
     int n = problem.n;
     int m = problem.m;
     return init_model(n, m, params);

--- a/ffm.h
+++ b/ffm.h
@@ -88,6 +88,10 @@ ffm_float* ffm_predict_batch(ffm_problem &data, ffm_model &model);
 
 void ffm_cleanup_prediction(ffm_float* f);
 
+ffm_int ffm_get_k_aligned(ffm_int k);
+
+ffm_int ffm_get_kALIGN();
+
 } // namespace ffm
 
 #endif // _LIBFFM_H

--- a/ffm/ffm.py
+++ b/ffm/ffm.py
@@ -210,7 +210,8 @@ class FFM():
     
     def get_W(self):
         '''
-        Returns the model vectors W of shape n x k, where n is the number of feature indexes.
+        Returns the model vectors W of shape n x m x k, where n is the number of feature indexes
+        and m is the number of fields.
         
         Given input X, the computation of probabilites can then be done in python as follows:
         

--- a/ffm/ffm.py
+++ b/ffm/ffm.py
@@ -207,35 +207,37 @@ class FFM():
             self.model.iteration(ffm_data)
 
         return self
-		
-	def get_W(self):
-		'''
-		Returns the model vectors W of shape n x k, where n is the number of feature indexes.
-		
-		Given input X, the computation of probabilites can then be done in python as follows:
-		
-		import itertools
-		i = 0 #the sample index for which we want to compute probabilities
-		sig = lambda x: 1/(1+np.exp(-x)) #sigmoid function
-		pairs = itertools.combinations(X[i],2)
-		proba = sig(sum( (v0*W[i0,j1]) @ (v1*W[i1,j0]) for (j0,i0,v0), (j1,i1,v1) in pairs ))
-		
-		This shoud be the same as model.predict(X)[i]		
-		'''
-			m = self._model.m
-		n = self._model.n
-		k = self._model.k
+    
+    def get_W(self):
+        '''
+        Returns the model vectors W of shape n x k, where n is the number of feature indexes.
+        
+        Given input X, the computation of probabilites can then be done in python as follows:
+        
+        import itertools
+        i = 0 #the sample index for which we want to compute probabilities
+        sig = lambda x: 1/(1+np.exp(-x)) #sigmoid function
+        pairs = itertools.combinations(X[i],2)
+        proba = sig(sum( (v0*W[i0,j1]) @ (v1*W[i1,j0]) for (j0,i0,v0), (j1,i1,v1) in pairs ))
+        print('python computation:',proba)
+    
+        #to crosscheck, this should be the same when ffm_data is generated from X:
+        print('C computation:',model.predict(ffm_data)[i])				
+        '''
+        m = self._model.m
+        n = self._model.n
+        k = self._model.k
 
-		k_aligned = self._lib.ffm_get_k_aligned(k)
-		kALIGN = self._lib.ffm_get_kALIGN()
-		align0 = 2*k_aligned
-		align1 = m*align0
+        k_aligned = _lib.ffm_get_k_aligned(k)
+        kALIGN = _lib.ffm_get_kALIGN()
+        align0 = 2*k_aligned
+        align1 = m*align0
 
-		W = np.ctypeslib.as_array(self._model.W,(1,n*align1))[0]
-		W = W.reshape((n,m,align0))
-		I = np.arange(k) + ( np.floor(np.arange(align0)/kALIGN).astype(int)*kALIGN )[:k]
-		W = W[:,:,I]
-		return W
+        W = np.ctypeslib.as_array(self._model.W,(1,n*align1))[0]
+        W = W.reshape((n,m,align0))
+        I = np.arange(k) + ( np.floor(np.arange(align0)/kALIGN).astype(int)*kALIGN )[:k]
+        W = W[:,:,I]
+        return W
 
 
 def read_model(path):


### PR DESCRIPTION
Tested e.g. with the following script:

```
import ffm
from sklearn.metrics import roc_auc_score

# prepare the data
# (field, index, value) format

X = [[(1, 2, 1), (2, 3, 1), (3, 5, 1)],
     [(1, 0, 1), (2, 3, 1), (3, 7, 1)],
     [(1, 1, 1), (2, 3, 1), (3, 7, 1), (3, 9, 1)],]

y = [1, 1, 0]

ffm_data = ffm.FFMData(X, y)


# train the model for 10 iterations

n_iter = 10

model = ffm.FFM(eta=0.1, lam=0.0001, k=4)
model.init_model(ffm_data)

for i in range(n_iter):
    print('iteration %d, ' % i, end='')
    model.iteration(ffm_data)

    y_pred = model.predict(ffm_data)
    auc = roc_auc_score(y, y_pred)
    print('train auc %.4f' % auc)

import numpy as np

import itertools
W = model.get_W()
i = 0 #the sample index for which we want to compute probabilities
sig = lambda x: 1/(1+np.exp(-x)) #sigmoid function
pairs = itertools.combinations(X[i],2)
proba = sig(sum( (v0*W[i0,j1]) @ (v1*W[i1,j0]) for (j0,i0,v0), (j1,i1,v1) in pairs ))
print('python computation:',proba)
print('C computation:',model.predict(ffm_data)[i]) #to crosscheck, this should be the same
```