### PR TITLE
Method to set the model weights from numpy array

### DIFF
--- a/ffm/ffm.py
+++ b/ffm/ffm.py
@@ -239,7 +239,27 @@ class FFM():
         I = np.arange(k) + ( np.floor(np.arange(align0)/kALIGN).astype(int)*kALIGN )[:k]
         W = W[:,:,I]
         return W
+   
+    def set_W(self,W):
+        """
+        Sets the model weights according to W
+        """
+        m = self._model.m
+        n = self._model.n
+        k = self._model.k
 
-
+        k_aligned = _lib.ffm_get_k_aligned(k)
+        kALIGN = _lib.ffm_get_kALIGN()
+        align0 = 2*k_aligned
+        align1 = m*align0
+   
+        W_ = np.ctypeslib.as_array(self._model.W,(1,n*align1))[0]
+        W_ = W_.reshape((n,m,align0))
+        I = np.arange(k) + ( np.floor(np.arange(align0)/kALIGN).astype(int)*kALIGN )[:k]
+        W_[:,:,I] = W
+        
+        self._model.W = np.ctypeslib.as_ctypes(W_.reshape(n*align1))
+    
+    
 def read_model(path):
     return FFM().read_model(path)


### PR DESCRIPTION
Can be tested with the following script. The weights W are rounded inside libffm, therefore the random matrix is not 100% conserved:
```
import ffm
from sklearn.metrics import roc_auc_score

# prepare the data
# (field, index, value) format

X = [[(1, 2, 1), (2, 3, 1), (3, 5, 1)],
     [(1, 0, 1), (2, 3, 1), (3, 7, 1)],
     [(1, 1, 1), (2, 3, 1), (3, 7, 1), (3, 9, 1)],]

y = [1, 1, 0]

ffm_data = ffm.FFMData(X, y)

# train the model for 10 iterations

n_iter = 10

model = ffm.FFM(eta=0.1, lam=0.0001, k=4)
model.init_model(ffm_data)

for i in range(n_iter):
    print('iteration %d, ' % i, end='')
    model.iteration(ffm_data)

    y_pred = model.predict(ffm_data)
    auc = roc_auc_score(y, y_pred)
    print('train auc %.4f' % auc)

W = model.get_W()

import numpy as np
W_random = np.random.random(W.shape)
W[:] = W_random
model.set_W(W)

# save the model 
model.save_model('ololo.bin')

# load it to reuse the model
model = ffm.read_model('ololo.bin')

W = model.get_W()

# libffm does some internal rounding, so values will slightly change
print( ( W_random - W ) < 0.00001 )
```