### PR TITLE
Simplify installation by using setuptools.Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# C
+*.so
+*.o
+
+# Python
+dist/
+build/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ This is a python wrapped for LibFFM library writen in C++
 
 Installing it:
 
-	make so
-	mv libffm.so ffm
-	python setup.py install
+	python setup.py install  # or python setup.py develop
 
 
 Using it:

--- a/ffm/ffm.py
+++ b/ffm/ffm.py
@@ -1,11 +1,6 @@
 # coding: utf-8
 
 import os
-path = os.path.dirname(__file__)
-lib_path = path + '/libffm.so'
-
-# binding code
-
 import numpy as np
 import ctypes
 
@@ -61,12 +56,20 @@ class FFM_Problem(ctypes.Structure):
         ("m", ctypes.c_int),
     ]
 
+
+def get_lib_path():
+    basedir = os.path.dirname(__file__)
+    for f in os.listdir(basedir):
+        if f.startswith('libffm') and f.endswith('.so'):
+            return os.path.join(basedir, f)
+    return ""
+
 FFM_Node_ptr = ctypes.POINTER(FFM_Node)
 FFM_Line_ptr = ctypes.POINTER(FFM_Line)
 FFM_Model_ptr = ctypes.POINTER(FFM_Model)
 FFM_Problem_ptr = ctypes.POINTER(FFM_Problem)
 
-_lib = ctypes.cdll.LoadLibrary(lib_path)
+_lib = ctypes.cdll.LoadLibrary(get_lib_path())
 
 _lib.ffm_convert_data.restype = FFM_Problem
 _lib.ffm_convert_data.argtypes = [FFM_Line_ptr, ctypes.c_int]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,18 @@
-from setuptools import setup
+from setuptools import setup, Extension
+
+
+ext = Extension(
+    "ffm.libffm",
+    extra_compile_args=[
+          "-Wall", "-O3",
+          "-std=c++0x", "-march=native",
+          "-DUSESSE", "-DUSEOMP"
+    ],
+    extra_link_args=['-fopenmp'],
+    sources=['ffm.cpp', 'timer.cpp'],
+    include_dirs=['.'],
+    language='c++',
+)
 
 # Please use setup_pip.py for generating and deploying pip installation
 # detailed instruction in setup_pip.py
@@ -9,6 +23,7 @@ setup(name='ffm',
       install_requires=[
           'numpy',
       ],
+      ext_modules=[ext],
       maintainer='',
       maintainer_email='',
       zip_safe=False,


### PR DESCRIPTION
Simplify installation, just run setup.py install.

```
$ CXX=/usr/local/bin/g++-8 python setup.py install
...
Using /Users/c-bata/src/github.com/alexeygrigorev/libffm-python/venv/lib/python3.7/site-packages/numpy-1.16.4-py3.7-macosx-10.14-x86_64.egg
Finished processing dependencies for ffm===7e8621d
$ ls venv/lib/python3.7/site-packages/ffm-7e8621d-py3.7-macosx-10.14-x86_64.egg/ffm/*.so
venv/lib/python3.7/site-packages/ffm-7e8621d-py3.7-macosx-10.14-x86_64.egg/ffm/libffm.cpython-37m-darwin.so
$ python
Python 3.7.2 (default, Feb 24 2019, 14:36:43) 
[Clang 10.0.0 (clang-1000.10.44.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import ffm
>>> 
```

or 

```
$ python setup.py develop
...
Finished processing dependencies for ffm===7e8621d
$ ls ./ffm/*.so
./ffm/libffm.cpython-37m-darwin.so
$ python
Python 3.7.2 (default, Feb 24 2019, 14:36:43) 
[Clang 10.0.0 (clang-1000.10.44.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import ffm
>>> 
```